### PR TITLE
fix bug where running ./craft causes invalid path alias error

### DIFF
--- a/src/BusinessLogic.php
+++ b/src/BusinessLogic.php
@@ -33,6 +33,13 @@ class BusinessLogic extends Module
         // Set alias for this module
         Craft::setAlias('@businesslogic', __DIR__);
 
+        // Set the controllerNamespace based on whether this is a console or web request
+        if (Craft::$app->getRequest()->getIsConsoleRequest()) {
+            $this->controllerNamespace = 'businesslogic\\console\\controllers';
+        } else {
+            $this->controllerNamespace = 'businesslogic\\controllers';
+        }
+
         // Run parent init
         parent::init();
 


### PR DESCRIPTION
I encountered errors when running the craft console command about an invalid path alias. Not sure if this is actually a bug, but I have applied this fix.